### PR TITLE
Fixed some README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ directory.
 Install
 =======
 
-```python
-python setup.py install
+```
+sudo python setup.py install
 ```
 
 Usage
 =====
 
 ```
-usage: diskspace.py [-h] [-o {desc,asc}] [-s HIDE] [-a | -d DEPTH] [-t] [DIR]
+usage: diskspace [-h] [-o {desc,asc}] [-s HIDE] [-a | -d DEPTH] [-t] [DIR]
 
 Analizes and reports the disk usage per folder
 


### PR DESCRIPTION
The install command is not a python command line and it requires superuser permissions. `sudo` resolve the problem at most common Linux systems.
Besides that, the usage does not require `.py` extension.